### PR TITLE
Fix/task

### DIFF
--- a/todoassistant.api/internals/service/taskService/srv.go
+++ b/todoassistant.api/internals/service/taskService/srv.go
@@ -228,23 +228,32 @@ func (t *taskSrv) PersistTask(req *taskEntity.CreateTaskReq) (*taskEntity.Create
 		return nil, ResponseEntity.NewValidatingError("Bad Data Input")
 	}
 
-	// //check if timeDueDate and StartDate is valid
-	// err = t.timeSrv.CheckFor339Format(req.EndTime)
-	// if err != nil {
-	// 	return nil, ResponseEntity.NewCustomServiceError("Bad Time Input", err)
-	// }
-
-	// err = t.timeSrv.CheckFor339Format(req.StartTime)
-	// if err != nil {
-	// 	return nil, ResponseEntity.NewCustomServiceError("Bad Time Input", err)
-	// }
-
-
 	//set time
 	req.CreatedAt = t.timeSrv.CurrentTime().Format(time.RFC3339)
 	//set id
 	req.TaskId = uuid.New().String()
 	req.Status = "PENDING"
+
+	//set start time and endtime
+	if req.StartTime == ""{
+		req.StartTime=t.timeSrv.CurrentTime().Format(time.RFC3339);
+	}
+
+	if req.EndTime == ""{
+		req.EndTime = t.timeSrv.CalcEndTime().Format(time.RFC3339)
+	}
+
+
+	//check if timeDueDate and StartDate is valid
+	err = t.timeSrv.CheckFor339Format(req.EndTime)
+	if err != nil {
+		return nil, ResponseEntity.NewCustomServiceError("Bad Time Input", err)
+	}
+
+	err = t.timeSrv.CheckFor339Format(req.StartTime)
+	if err != nil {
+		return nil, ResponseEntity.NewCustomServiceError("Bad Time Input", err)
+	}
 
 	// create a reminder
 	switch req.Repeat {

--- a/todoassistant.api/internals/service/timeSrv/srv.go
+++ b/todoassistant.api/internals/service/timeSrv/srv.go
@@ -6,6 +6,7 @@ type TimeService interface {
 	CurrentTime() time.Time
 	TimeSince(time2 time.Time) time.Duration
 	CheckFor339Format(time string) error
+	CalcEndTime() time.Time
 }
 
 type timeStruct struct{}
@@ -30,4 +31,10 @@ func (t timeStruct) CurrentTime() time.Time {
 
 func (t timeStruct) TimeSince(time2 time.Time) time.Duration {
 	return time.Since(time2)
+}
+
+func (t timeStruct) CalcEndTime() time.Time{
+	now := time.Now()
+	endOfDay := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, time.Local)
+	return endOfDay
 }

--- a/todoassistant.api/internals/service/timeSrv/srv_test.go
+++ b/todoassistant.api/internals/service/timeSrv/srv_test.go
@@ -1,0 +1,25 @@
+package timeSrv
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func Test_timeStruct_CalcEndTime(t *testing.T) {
+	tests := []struct {
+		name string
+		tr   timeStruct
+		want time.Time
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := timeStruct{}
+			if got := tr.CalcEndTime(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("timeStruct.CalcEndTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Newly created tasks that do not provide start-time and end-time now have a default start time of same day and end-time of same day 11:59pm

e.g when a task is created by supplying just title as payload, this is the response

`"data": {
        "task_id": "b597a935-97e3-458c-b704-8c9bb008a8f3",
        "title": "My first Task",
        "description": "",
        "start_time": "2023-02-10T14:14:07+02:00",
        "end_time": "2023-02-10T23:59:59+02:00",
        "va_option": "",
        "repeat": "never",
        "assigned": "",
        "files": null,
        "project_id": "",
        "notify": false,
        "status": "",
        "created_at": "",
        "updated_at": "",
        "scheduled_date": "",
        "features": {
            "is_completed": false,
            "is_expired": false,
            "is_scheduled": false,
            "is_assigned": false
        }
    }`